### PR TITLE
standardization of jobs

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -26,24 +26,22 @@ variables:
 targets:
   dev:
     default: true
-    mode: development
     presets:
-      name_prefix: ${bundle.target}_${workspace.current_user.short_name}_
+      name_prefix: job_${bundle.name}_${bundle.target}_
     workspace:
       host: https://dbc-da6511e6-81a8.cloud.databricks.com
       root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.target}/${bundle.name}
   qa:
     default: false
-    mode: development
     presets:
-      name_prefix: ${bundle.target}_${workspace.current_user.short_name}_
+      name_prefix: job_${bundle.name}_${bundle.target}_
     workspace:
       host: https://dbc-da6511e6-81a8.cloud.databricks.com
       root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.target}/${bundle.name}
   prod:
     default: false
     presets:
-      name_prefix: ${bundle.target}_
+      name_prefix: job_${bundle.name}_${bundle.target}_
     workspace:
       host: https://dbc-da6511e6-81a8.cloud.databricks.com
       root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.target}/${bundle.name}

--- a/resources/data-lake-jobs/olist_ingestion_pipeline.yml
+++ b/resources/data-lake-jobs/olist_ingestion_pipeline.yml
@@ -1,7 +1,7 @@
 resources:
   jobs:
     serverless_job:
-      name: olist_ingestion_pipeline
+      name: datalake_ingestion_pipeline
       max_concurrent_runs: 3
       tags:
         env: ${bundle.target}


### PR DESCRIPTION
## Summary by Sourcery

Standardize job naming conventions across environments and rename the ingestion pipeline resource

Enhancements:
- Unify Databricks job name prefixes to use the pattern job_{bundle.name}_{bundle.target} for dev, qa, and prod
- Remove obsolete mode fields from dev and qa targets in databricks.yml
- Rename the olist_ingestion_pipeline job resource to datalake_ingestion_pipeline for consistency